### PR TITLE
Use local phpcs config file if available.

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,10 @@
     {
       "name": "Victor Uriarte",
       "url": "https://github.com/vmuriart"
+    },
+    {
+      "name": "Daniel Brodin",
+      "url": "https://github.com/danielbrodin"
     }
   ],
   "engines": {

--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -20,6 +20,10 @@ module.exports = class PHPCBF extends Beautifier
 
   beautify: (text, language, options) ->
     @debug('phpcbf', options)
+    standardFiles = ['phpcs.xml', 'phpcs.xml.dist', 'phpcs.ruleset.xml', 'ruleset.xml']
+    standardFile = @findFile(atom.project.getPaths()[0], standardFiles);
+
+    options.standard = standardFile if standardFile
 
     isWin = @isWindows
     if isWin

--- a/src/languages/php.coffee
+++ b/src/languages/php.coffee
@@ -42,6 +42,6 @@ module.exports = {
       title: "PHPCBF Standard"
       type: 'string'
       default: "",
-      description: "Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules"
+      description: "Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root."
 
 }


### PR DESCRIPTION
PHP CodeSniffer and the phpcbf script supports a settings file, so I think that should be used if available before using the default standard.